### PR TITLE
Features: Server Config, Show Speed Stat and Damage Percentages

### DIFF
--- a/cobblemonextendedbattleui-server.json.example
+++ b/cobblemonextendedbattleui-server.json.example
@@ -1,0 +1,23 @@
+{
+  "schemaVersion": 1,
+  "enableTeamIndicators": true,
+  "sync_enableTeamIndicators": false,
+  "teamIndicatorRepositioningEnabled": true,
+  "sync_teamIndicatorRepositioningEnabled": false,
+  "enableBattleInfoPanel": true,
+  "sync_enableBattleInfoPanel": false,
+  "enableBattleLog": true,
+  "sync_enableBattleLog": false,
+  "enableBattleLogDamagePercentages": true,
+  "sync_enableBattleLogDamagePercentages": false,
+  "enableMoveTooltips": true,
+  "sync_enableMoveTooltips": false,
+  "showTeraType": false,
+  "sync_showTeraType": false,
+  "showStatRanges": true,
+  "sync_showStatRanges": false,
+  "showOpponentSpeedRange": true,
+  "sync_showOpponentSpeedRange": false,
+  "showBaseCritRate": false,
+  "sync_showBaseCritRate": false
+}

--- a/src/main/java/com/cobblemonextendedbattleui/mixin/BattleHealthChangeHandlerMixin.java
+++ b/src/main/java/com/cobblemonextendedbattleui/mixin/BattleHealthChangeHandlerMixin.java
@@ -38,7 +38,7 @@ public class BattleHealthChangeHandlerMixin {
         // Skip entirely if no features need HP tracking
         boolean needsDamage = PanelConfig.INSTANCE.needsDamageTracking();
         boolean needsKOTracking = PanelConfig.INSTANCE.needsBattleStateTracking() ||
-                                   PanelConfig.INSTANCE.getEnableTeamIndicators();
+                                   PanelConfig.INSTANCE.getEnableTeamIndicatorsEffective();
         if (!needsDamage && !needsKOTracking) return;
 
         ClientBattle battle = CobblemonClient.INSTANCE.getBattle();
@@ -88,7 +88,7 @@ public class BattleHealthChangeHandlerMixin {
 
                 // Track KO at the moment HP reaches 0 (only if needed by enabled features)
                 if (newPercent <= 0 && needsKOTracking) {
-                    if (PanelConfig.INSTANCE.getEnableTeamIndicators()) {
+                    if (PanelConfig.INSTANCE.getEnableTeamIndicatorsEffective()) {
                         TeamIndicatorUI.INSTANCE.markPokemonAsKO(uuid);
                     }
                     if (PanelConfig.INSTANCE.needsBattleStateTracking()) {

--- a/src/main/java/com/cobblemonextendedbattleui/mixin/BattleMessageHandlerMixin.java
+++ b/src/main/java/com/cobblemonextendedbattleui/mixin/BattleMessageHandlerMixin.java
@@ -36,7 +36,7 @@ public class BattleMessageHandlerMixin {
         }
 
         // Store messages in battle log only if the battle log feature is enabled
-        if (PanelConfig.INSTANCE.getEnableBattleLog()) {
+        if (PanelConfig.INSTANCE.getEnableBattleLogEffective()) {
             BattleLog.INSTANCE.processMessages(packet.getMessages());
             // Also prevent Cobblemon from showing messages in chat (we show our own log)
             ci.cancel();

--- a/src/main/java/com/cobblemonextendedbattleui/mixin/BattleMessagePaneMixin.java
+++ b/src/main/java/com/cobblemonextendedbattleui/mixin/BattleMessagePaneMixin.java
@@ -29,7 +29,7 @@ public class BattleMessagePaneMixin {
         cancellable = true
     )
     private void onRenderWidget(DrawContext context, int mouseX, int mouseY, float delta, CallbackInfo ci) {
-        if (PanelConfig.INSTANCE.getEnableBattleLog()) {
+        if (PanelConfig.INSTANCE.getEnableBattleLogEffective()) {
             ci.cancel();
         }
     }

--- a/src/main/java/com/cobblemonextendedbattleui/mixin/BattleMoveSelectionMixin.java
+++ b/src/main/java/com/cobblemonextendedbattleui/mixin/BattleMoveSelectionMixin.java
@@ -32,7 +32,7 @@ public class BattleMoveSelectionMixin {
      */
     @Inject(method = "renderWidget", at = @At("HEAD"), remap = true)
     private void onRenderWidgetHead(DrawContext context, int mouseX, int mouseY, float delta, CallbackInfo ci) {
-        if (PanelConfig.INSTANCE.getEnableMoveTooltips()) {
+        if (PanelConfig.INSTANCE.getEnableMoveTooltipsEffective()) {
             MoveTooltipRenderer.INSTANCE.clear();
         }
     }
@@ -43,7 +43,7 @@ public class BattleMoveSelectionMixin {
      */
     @Inject(method = "renderWidget", at = @At("RETURN"), remap = true)
     private void onRenderWidgetReturn(DrawContext context, int mouseX, int mouseY, float delta, CallbackInfo ci) {
-        if (!PanelConfig.INSTANCE.getEnableMoveTooltips()) {
+        if (!PanelConfig.INSTANCE.getEnableMoveTooltipsEffective()) {
             return;
         }
 

--- a/src/main/java/com/cobblemonextendedbattleui/mixin/MouseScrollMixin.java
+++ b/src/main/java/com/cobblemonextendedbattleui/mixin/MouseScrollMixin.java
@@ -34,25 +34,25 @@ public abstract class MouseScrollMixin {
         // Only intercept during battle
         if (CobblemonClient.INSTANCE.getBattle() != null) {
             // Let the move tooltip try to handle the scroll first (highest priority when in Fight menu)
-            if (PanelConfig.INSTANCE.getEnableMoveTooltips() &&
+            if (PanelConfig.INSTANCE.getEnableMoveTooltipsEffective() &&
                 MoveTooltipRenderer.INSTANCE.handleScroll(vertical)) {
                 ci.cancel();
                 return;
             }
             // Then let the team indicator tooltip try
-            if (PanelConfig.INSTANCE.getEnableTeamIndicators() &&
+            if (PanelConfig.INSTANCE.getEnableTeamIndicatorsEffective() &&
                 TeamIndicatorUI.INSTANCE.handleScroll(vertical)) {
                 ci.cancel();
                 return;
             }
             // Then let the battle log widget try
-            if (PanelConfig.INSTANCE.getEnableBattleLog() &&
+            if (PanelConfig.INSTANCE.getEnableBattleLogEffective() &&
                 BattleLogWidget.INSTANCE.onScroll(this.x, this.y, vertical)) {
                 ci.cancel();
                 return;
             }
             // Finally try the info panel
-            if (PanelConfig.INSTANCE.getEnableBattleInfoPanel() &&
+            if (PanelConfig.INSTANCE.getEnableBattleInfoPanelEffective() &&
                 BattleInfoPanel.INSTANCE.onScroll(this.x, this.y, vertical)) {
                 ci.cancel();
             }

--- a/src/main/kotlin/com/cobblemonextendedbattleui/BattleInfoRenderer.kt
+++ b/src/main/kotlin/com/cobblemonextendedbattleui/BattleInfoRenderer.kt
@@ -26,18 +26,18 @@ object BattleInfoRenderer {
             }
         }
 
-        if (PanelConfig.enableTeamIndicators) {
+        if (PanelConfig.enableTeamIndicatorsEffective) {
             TeamIndicatorUI.render(context)
         }
-        if (PanelConfig.enableBattleInfoPanel) {
+        if (PanelConfig.enableBattleInfoPanelEffective) {
             BattleInfoPanel.render(context)
         }
-        if (PanelConfig.enableBattleLog) {
+        if (PanelConfig.enableBattleLogEffective) {
             BattleLogWidget.render(context)
         }
 
         // Tooltip renders LAST to appear on top of everything
-        if (PanelConfig.enableTeamIndicators) {
+        if (PanelConfig.enableTeamIndicatorsEffective) {
             TeamIndicatorUI.renderHoverTooltip(context)
         }
     }

--- a/src/main/kotlin/com/cobblemonextendedbattleui/BattleLogWidget.kt
+++ b/src/main/kotlin/com/cobblemonextendedbattleui/BattleLogWidget.kt
@@ -137,7 +137,7 @@ object BattleLogWidget {
      * Check if mouse is currently over the battle log widget.
      */
     fun isMouseOverWidget(): Boolean {
-        if (!PanelConfig.enableBattleLog) return false
+        if (!PanelConfig.enableBattleLogEffective) return false
         val mc = MinecraftClient.getInstance()
         val mouseX = (mc.mouse.x * mc.window.scaledWidth / mc.window.width).toInt()
         val mouseY = (mc.mouse.y * mc.window.scaledHeight / mc.window.height).toInt()
@@ -146,7 +146,7 @@ object BattleLogWidget {
     }
 
     fun render(context: DrawContext) {
-        if (!PanelConfig.enableBattleLog) return
+        if (!PanelConfig.enableBattleLogEffective) return
         val battle = CobblemonClient.battle ?: return
 
         // Track minimized state - render greyed out instead of hiding
@@ -213,7 +213,7 @@ object BattleLogWidget {
     }
 
     fun onScroll(mouseX: Double, mouseY: Double, deltaY: Double): Boolean {
-        if (!PanelConfig.enableBattleLog) return false
+        if (!PanelConfig.enableBattleLogEffective) return false
         if (isMinimised) return false  // Read-only when minimized
 
         val mc = MinecraftClient.getInstance()

--- a/src/main/kotlin/com/cobblemonextendedbattleui/ClientServerFeatureSync.kt
+++ b/src/main/kotlin/com/cobblemonextendedbattleui/ClientServerFeatureSync.kt
@@ -1,0 +1,30 @@
+package com.cobblemonextendedbattleui
+
+import com.cobblemonextendedbattleui.network.FeatureSyncS2CPayload
+
+/**
+ * Client-only: server-forced feature toggles received on join. Cleared on disconnect.
+ */
+object ClientServerFeatureSync {
+    private val overrides: MutableMap<String, Boolean> = linkedMapOf()
+
+    fun clear() {
+        overrides.clear()
+    }
+
+    fun applyPayload(payload: FeatureSyncS2CPayload) {
+        overrides.clear()
+        if (payload.schemaVersion != FeatureSyncS2CPayload.SCHEMA_VERSION) {
+            CobblemonExtendedBattleUI.LOGGER.warn(
+                "ClientServerFeatureSync: Ignoring feature sync packet (schema ${payload.schemaVersion}, expected ${FeatureSyncS2CPayload.SCHEMA_VERSION})"
+            )
+            return
+        }
+        for ((key, value) in payload.entries) {
+            overrides[key] = value
+        }
+        CobblemonExtendedBattleUI.LOGGER.debug("ClientServerFeatureSync: Applied ${overrides.size} server overrides")
+    }
+
+    fun getOverride(key: String): Boolean? = overrides[key]
+}

--- a/src/main/kotlin/com/cobblemonextendedbattleui/CobblemonExtendedBattleUI.kt
+++ b/src/main/kotlin/com/cobblemonextendedbattleui/CobblemonExtendedBattleUI.kt
@@ -1,6 +1,11 @@
 package com.cobblemonextendedbattleui
 
+import com.cobblemonextendedbattleui.network.FeatureSyncS2CPayload
 import net.fabricmc.api.ModInitializer
+import net.fabricmc.fabric.api.event.lifecycle.v1.ServerLifecycleEvents
+import net.fabricmc.fabric.api.networking.v1.PayloadTypeRegistry
+import net.fabricmc.fabric.api.networking.v1.ServerPlayConnectionEvents
+import net.fabricmc.fabric.api.networking.v1.ServerPlayNetworking
 import org.slf4j.LoggerFactory
 
 object CobblemonExtendedBattleUI : ModInitializer {
@@ -8,6 +13,17 @@ object CobblemonExtendedBattleUI : ModInitializer {
     val LOGGER = LoggerFactory.getLogger(MOD_ID)
 
     override fun onInitialize() {
+        PayloadTypeRegistry.playS2C().register(FeatureSyncS2CPayload.ID, FeatureSyncS2CPayload.CODEC)
+
+        ServerLifecycleEvents.SERVER_STARTING.register { _ ->
+            ServerPanelConfig.load()
+        }
+
+        ServerPlayConnectionEvents.JOIN.register { handler, _, _ ->
+            val player = handler.player
+            ServerPlayNetworking.send(player, ServerPanelConfig.buildSyncPayload())
+        }
+
         LOGGER.info("Cobblemon Extended Battle UI initialized")
     }
 }

--- a/src/main/kotlin/com/cobblemonextendedbattleui/CobblemonExtendedBattleUIClient.kt
+++ b/src/main/kotlin/com/cobblemonextendedbattleui/CobblemonExtendedBattleUIClient.kt
@@ -1,6 +1,9 @@
 package com.cobblemonextendedbattleui
 
+import com.cobblemonextendedbattleui.network.FeatureSyncS2CPayload
 import net.fabricmc.api.ClientModInitializer
+import net.fabricmc.fabric.api.client.networking.v1.ClientPlayConnectionEvents
+import net.fabricmc.fabric.api.client.networking.v1.ClientPlayNetworking
 import net.fabricmc.fabric.api.client.keybinding.v1.KeyBindingHelper
 import net.fabricmc.fabric.api.client.rendering.v1.HudRenderCallback
 import net.minecraft.client.option.KeyBinding
@@ -18,6 +21,13 @@ object CobblemonExtendedBattleUIClient : ClientModInitializer {
 
     override fun onInitializeClient() {
         CobblemonExtendedBattleUI.LOGGER.info("Cobblemon Extended Battle UI Client initializing...")
+
+        ClientPlayNetworking.registerGlobalReceiver(FeatureSyncS2CPayload.ID) { payload, _ ->
+            ClientServerFeatureSync.applyPayload(payload)
+        }
+        ClientPlayConnectionEvents.DISCONNECT.register { _, _ ->
+            ClientServerFeatureSync.clear()
+        }
 
         BattleInfoPanel.initialize()
         registerKeybindings()

--- a/src/main/kotlin/com/cobblemonextendedbattleui/ModMenuIntegration.kt
+++ b/src/main/kotlin/com/cobblemonextendedbattleui/ModMenuIntegration.kt
@@ -3,6 +3,7 @@ package com.cobblemonextendedbattleui
 import com.terraformersmc.modmenu.api.ConfigScreenFactory
 import com.terraformersmc.modmenu.api.ModMenuApi
 import me.shedaniel.clothconfig2.api.ConfigBuilder
+import me.shedaniel.clothconfig2.api.Requirement
 import net.minecraft.client.gui.screen.Screen
 import net.minecraft.text.Text
 
@@ -61,15 +62,25 @@ class ModMenuIntegration : ModMenuApi {
                 .build()
         )
 
-        // Battle Log toggle
+        val battleLogEntry = entryBuilder.startBooleanToggle(
+            Text.translatable("cobblemonextendedbattleui.config.enableBattleLog"),
+            PanelConfig.enableBattleLog
+        )
+            .setDefaultValue(true)
+            .setTooltip(Text.translatable("cobblemonextendedbattleui.config.enableBattleLog.tooltip"))
+            .setSaveConsumer { value -> PanelConfig.setEnableBattleLog(value) }
+            .build()
+        general.addEntry(battleLogEntry)
+
         general.addEntry(
             entryBuilder.startBooleanToggle(
-                Text.translatable("cobblemonextendedbattleui.config.enableBattleLog"),
-                PanelConfig.enableBattleLog
+                Text.translatable("cobblemonextendedbattleui.config.enableBattleLogDamagePercentages"),
+                PanelConfig.enableBattleLogDamagePercentages
             )
                 .setDefaultValue(true)
-                .setTooltip(Text.translatable("cobblemonextendedbattleui.config.enableBattleLog.tooltip"))
-                .setSaveConsumer { value -> PanelConfig.setEnableBattleLog(value) }
+                .setTooltip(Text.translatable("cobblemonextendedbattleui.config.enableBattleLogDamagePercentages.tooltip"))
+                .setSaveConsumer { value -> PanelConfig.setEnableBattleLogDamagePercentages(value) }
+                .setRequirement(Requirement.isTrue(battleLogEntry))
                 .build()
         )
 
@@ -110,6 +121,17 @@ class ModMenuIntegration : ModMenuApi {
                 .setDefaultValue(true)
                 .setTooltip(Text.translatable("cobblemonextendedbattleui.config.showStatRanges.tooltip"))
                 .setSaveConsumer { value -> PanelConfig.setShowStatRanges(value) }
+                .build()
+        )
+
+        tooltipOptions.addEntry(
+            entryBuilder.startBooleanToggle(
+                Text.translatable("cobblemonextendedbattleui.config.showOpponentSpeedRange"),
+                PanelConfig.showOpponentSpeedRange
+            )
+                .setDefaultValue(true)
+                .setTooltip(Text.translatable("cobblemonextendedbattleui.config.showOpponentSpeedRange.tooltip"))
+                .setSaveConsumer { value -> PanelConfig.setShowOpponentSpeedRange(value) }
                 .build()
         )
 

--- a/src/main/kotlin/com/cobblemonextendedbattleui/MoveTooltipRenderer.kt
+++ b/src/main/kotlin/com/cobblemonextendedbattleui/MoveTooltipRenderer.kt
@@ -125,7 +125,7 @@ object MoveTooltipRenderer {
 
     fun renderTooltip(context: DrawContext) {
         val move = hoveredMove ?: return
-        if (!PanelConfig.enableMoveTooltips) return
+        if (!PanelConfig.enableMoveTooltipsEffective) return
 
         val mc = MinecraftClient.getInstance()
         val screenWidth = mc.window.scaledWidth
@@ -369,7 +369,7 @@ object MoveTooltipRenderer {
             var critBonus = 0
             if (hasSuperLuck) critBonus++
             if (hasCritItem) critBonus++
-            val shouldShowCrit = PanelConfig.showBaseCritRate || baseCritRatio > 1.0 || critBonus > 0
+            val shouldShowCrit = PanelConfig.showBaseCritRateEffective || baseCritRatio > 1.0 || critBonus > 0
             if (shouldShowCrit) {
                 val basePct = critRatioToPercent(baseCritRatio)
                 if (critBonus > 0) {

--- a/src/main/kotlin/com/cobblemonextendedbattleui/PanelConfig.kt
+++ b/src/main/kotlin/com/cobblemonextendedbattleui/PanelConfig.kt
@@ -31,6 +31,10 @@ object PanelConfig {
     var enableBattleLog: Boolean = true
         private set
 
+    // Extra damage/healing percentage lines in the battle log (no effect if enableBattleLog is false)
+    var enableBattleLogDamagePercentages: Boolean = true
+        private set
+
     // Enable/disable move tooltips on Fight menu (shows power, accuracy, effectiveness)
     var enableMoveTooltips: Boolean = true
         private set
@@ -142,6 +146,10 @@ object PanelConfig {
     var showStatRanges: Boolean = true
         private set
 
+    // Show estimated speed range (min–max) for opponent Pokemon in tooltips; label/stage always shown
+    var showOpponentSpeedRange: Boolean = true
+        private set
+
     // Show base crit rate in move tooltips (even when not boosted)
     // Disabled by default due to noisiness.
     var showBaseCritRate: Boolean = false
@@ -176,6 +184,8 @@ object PanelConfig {
         val enableTeamIndicators: Boolean = true,
         val enableBattleInfoPanel: Boolean = true,
         val enableBattleLog: Boolean = true,
+        /** Null when absent from older config files; treated as true when loading. */
+        val enableBattleLogDamagePercentages: Boolean? = null,
         val enableMoveTooltips: Boolean = true,
         // Panel settings
         val panelX: Int? = null,
@@ -207,6 +217,8 @@ object PanelConfig {
         // Tooltip display options
         val showTeraType: Boolean = false,
         val showStatRanges: Boolean = true,
+        /** Null when absent from older config files; treated as true when loading. */
+        val showOpponentSpeedRange: Boolean? = null,
         val showBaseCritRate: Boolean = false
     )
 
@@ -218,6 +230,7 @@ object PanelConfig {
                 enableTeamIndicators = data.enableTeamIndicators
                 enableBattleInfoPanel = data.enableBattleInfoPanel
                 enableBattleLog = data.enableBattleLog
+                enableBattleLogDamagePercentages = data.enableBattleLogDamagePercentages ?: true
                 enableMoveTooltips = data.enableMoveTooltips
                 // Panel settings
                 panelX = data.panelX
@@ -253,8 +266,9 @@ object PanelConfig {
                 // Tooltip display options
                 showTeraType = data.showTeraType
                 showStatRanges = data.showStatRanges
+                showOpponentSpeedRange = data.showOpponentSpeedRange ?: true
                 showBaseCritRate = data.showBaseCritRate
-                CobblemonExtendedBattleUI.LOGGER.info("PanelConfig: Loaded config - features: team=$enableTeamIndicators, panel=$enableBattleInfoPanel, log=$enableBattleLog, moveTooltips=$enableMoveTooltips")
+                CobblemonExtendedBattleUI.LOGGER.info("PanelConfig: Loaded config - features: team=$enableTeamIndicators, panel=$enableBattleInfoPanel, log=$enableBattleLog, logDamagePct=$enableBattleLogDamagePercentages, moveTooltips=$enableMoveTooltips")
             }
         } catch (e: Exception) {
             CobblemonExtendedBattleUI.LOGGER.warn("PanelConfig: Failed to load config, using defaults: ${e.message}")
@@ -267,6 +281,7 @@ object PanelConfig {
                 enableTeamIndicators = enableTeamIndicators,
                 enableBattleInfoPanel = enableBattleInfoPanel,
                 enableBattleLog = enableBattleLog,
+                enableBattleLogDamagePercentages = enableBattleLogDamagePercentages,
                 enableMoveTooltips = enableMoveTooltips,
                 panelX = panelX,
                 panelY = panelY,
@@ -293,6 +308,7 @@ object PanelConfig {
                 moveTooltipFontScale = moveTooltipFontScale,
                 showTeraType = showTeraType,
                 showStatRanges = showStatRanges,
+                showOpponentSpeedRange = showOpponentSpeedRange,
                 showBaseCritRate = showBaseCritRate
             )
             configFile.parentFile?.mkdirs()
@@ -454,6 +470,10 @@ object PanelConfig {
         enableBattleLog = enabled
     }
 
+    fun setEnableBattleLogDamagePercentages(enabled: Boolean) {
+        enableBattleLogDamagePercentages = enabled
+    }
+
     fun setEnableMoveTooltips(enabled: Boolean) {
         enableMoveTooltips = enabled
     }
@@ -470,9 +490,47 @@ object PanelConfig {
         showStatRanges = show
     }
 
+    fun setShowOpponentSpeedRange(show: Boolean) {
+        showOpponentSpeedRange = show
+    }
+
     fun setShowBaseCritRate(show: Boolean) {
         showBaseCritRate = show
     }
+
+    // ═══════════════════════════════════════════════════════════════════════════
+    // Server-synced effective values (local config when server does not override)
+    // ═══════════════════════════════════════════════════════════════════════════
+
+    val enableTeamIndicatorsEffective: Boolean
+        get() = ClientServerFeatureSync.getOverride("enableTeamIndicators") ?: enableTeamIndicators
+
+    val teamIndicatorRepositioningEnabledEffective: Boolean
+        get() = ClientServerFeatureSync.getOverride("teamIndicatorRepositioningEnabled") ?: teamIndicatorRepositioningEnabled
+
+    val enableBattleInfoPanelEffective: Boolean
+        get() = ClientServerFeatureSync.getOverride("enableBattleInfoPanel") ?: enableBattleInfoPanel
+
+    val enableBattleLogEffective: Boolean
+        get() = ClientServerFeatureSync.getOverride("enableBattleLog") ?: enableBattleLog
+
+    val enableBattleLogDamagePercentagesEffective: Boolean
+        get() = ClientServerFeatureSync.getOverride("enableBattleLogDamagePercentages") ?: enableBattleLogDamagePercentages
+
+    val enableMoveTooltipsEffective: Boolean
+        get() = ClientServerFeatureSync.getOverride("enableMoveTooltips") ?: enableMoveTooltips
+
+    val showTeraTypeEffective: Boolean
+        get() = ClientServerFeatureSync.getOverride("showTeraType") ?: showTeraType
+
+    val showStatRangesEffective: Boolean
+        get() = ClientServerFeatureSync.getOverride("showStatRanges") ?: showStatRanges
+
+    val showOpponentSpeedRangeEffective: Boolean
+        get() = ClientServerFeatureSync.getOverride("showOpponentSpeedRange") ?: showOpponentSpeedRange
+
+    val showBaseCritRateEffective: Boolean
+        get() = ClientServerFeatureSync.getOverride("showBaseCritRate") ?: showBaseCritRate
 
     // ═══════════════════════════════════════════════════════════════════════════
     // Feature toggle helpers (for mixins to check tracking dependencies)
@@ -483,11 +541,13 @@ object PanelConfig {
      * Needed for both battle info panel (weather, terrain, conditions, stats)
      * and team indicator tooltips (stat changes, volatile statuses).
      */
-    fun needsBattleStateTracking(): Boolean = enableBattleInfoPanel || enableTeamIndicators
+    fun needsBattleStateTracking(): Boolean =
+        enableBattleInfoPanelEffective || enableTeamIndicatorsEffective
 
     /**
      * Returns true if DamageTracker should track HP changes.
-     * Only needed for battle log damage/healing percentages.
+     * Only used for optional battle log damage/healing percentage lines; requires custom battle log.
      */
-    fun needsDamageTracking(): Boolean = enableBattleLog
+    fun needsDamageTracking(): Boolean =
+        enableBattleLogEffective && enableBattleLogDamagePercentagesEffective
 }

--- a/src/main/kotlin/com/cobblemonextendedbattleui/PokemonInfoPopup.kt
+++ b/src/main/kotlin/com/cobblemonextendedbattleui/PokemonInfoPopup.kt
@@ -185,7 +185,7 @@ object PokemonInfoPopup {
         val vPad = UIUtils.CELL_VPAD_TOP + UIUtils.CELL_VPAD_BOTTOM
 
         // Header: name+level, types+hp, optional tera
-        val hasTera = !data.isTerastallized && PanelConfig.showTeraType && data.teraType != null
+        val hasTera = !data.isTerastallized && PanelConfig.showTeraTypeEffective && data.teraType != null
         val headerLines = if (hasTera) 3 else 2
         val headerCellH = vPad + headerLines * lineH
 
@@ -346,7 +346,7 @@ object PokemonInfoPopup {
         curY += lineH
 
         // Line 3 (optional): Tera type
-        if (!data.isTerastallized && PanelConfig.showTeraType && data.teraType != null) {
+        if (!data.isTerastallized && PanelConfig.showTeraTypeEffective && data.teraType != null) {
             val et = ElementalTypes.get(data.teraType.showdownId())
             val teraName = et?.displayName?.string ?: data.teraType.name
             val teraColor = et?.let { UIUtils.getTypeColor(it) } ?: TeamIndicatorUI.TOOLTIP_TEXT
@@ -394,7 +394,7 @@ object PokemonInfoPopup {
             val gap = tr.getWidth("  ") * fontScale
             when {
                 // Player Pokemon: show actual → effective for all stats
-                data.isPlayerPokemon && PanelConfig.showStatRanges -> {
+                data.isPlayerPokemon && PanelConfig.showStatRangesEffective -> {
                     val actualValue = getActualStat(data, stat)
                     if (actualValue != null) {
                         val effective = calculateEffectiveStat(actualValue, stat, stage, data)
@@ -422,9 +422,10 @@ object PokemonInfoPopup {
                         }
                     }
                 }
-                // Opponent Pokemon: show speed range inline
+                // Opponent Pokemon: optional speed range inline (label/stage always drawn above)
                 !data.isPlayerPokemon && stat == BattleStateTracker.BattleStat.SPEED
-                    && data.pokemonId != null && data.level != null -> {
+                    && data.pokemonId != null && data.level != null
+                    && PanelConfig.showOpponentSpeedRangeEffective -> {
                     val range = TeamIndicatorUI.calculateOpponentSpeedRange(
                         data.uuid, data.pokemonId, data.level, stage,
                         data.statusCondition, data.item, data.form

--- a/src/main/kotlin/com/cobblemonextendedbattleui/ServerPanelConfig.kt
+++ b/src/main/kotlin/com/cobblemonextendedbattleui/ServerPanelConfig.kt
@@ -1,0 +1,93 @@
+package com.cobblemonextendedbattleui
+
+import com.cobblemonextendedbattleui.network.FeatureSyncS2CPayload
+import com.google.gson.Gson
+import com.google.gson.GsonBuilder
+import net.fabricmc.loader.api.FabricLoader
+import java.io.File
+
+/**
+ * Dedicated / integrated server: [SERVER_CONFIG_FILE] in the config directory.
+ * Only feature toggles; each value can be pushed to clients when `sync_*` is true.
+ */
+object ServerPanelConfig {
+    private val gson: Gson = GsonBuilder().setPrettyPrinting().create()
+    private val configFile: File by lazy {
+        FabricLoader.getInstance().configDir.resolve(SERVER_CONFIG_FILE_NAME).toFile()
+    }
+
+    const val SERVER_CONFIG_FILE_NAME = "cobblemonextendedbattleui-server.json"
+
+    data class Data(
+        val schemaVersion: Int = 1,
+        val enableTeamIndicators: Boolean = true,
+        val sync_enableTeamIndicators: Boolean = false,
+        val teamIndicatorRepositioningEnabled: Boolean = true,
+        val sync_teamIndicatorRepositioningEnabled: Boolean = false,
+        val enableBattleInfoPanel: Boolean = true,
+        val sync_enableBattleInfoPanel: Boolean = false,
+        val enableBattleLog: Boolean = true,
+        val sync_enableBattleLog: Boolean = false,
+        val enableBattleLogDamagePercentages: Boolean = true,
+        val sync_enableBattleLogDamagePercentages: Boolean = false,
+        val enableMoveTooltips: Boolean = true,
+        val sync_enableMoveTooltips: Boolean = false,
+        val showTeraType: Boolean = false,
+        val sync_showTeraType: Boolean = false,
+        val showStatRanges: Boolean = true,
+        val sync_showStatRanges: Boolean = false,
+        val showOpponentSpeedRange: Boolean = true,
+        val sync_showOpponentSpeedRange: Boolean = false,
+        val showBaseCritRate: Boolean = false,
+        val sync_showBaseCritRate: Boolean = false
+    )
+
+    private var data: Data = Data()
+
+    fun load() {
+        try {
+            if (configFile.exists()) {
+                data = gson.fromJson(configFile.readText(), Data::class.java) ?: Data()
+                CobblemonExtendedBattleUI.LOGGER.info("ServerPanelConfig: Loaded $SERVER_CONFIG_FILE_NAME")
+            } else {
+                data = Data()
+                save()
+                CobblemonExtendedBattleUI.LOGGER.info("ServerPanelConfig: Created default $SERVER_CONFIG_FILE_NAME")
+            }
+        } catch (e: Exception) {
+            CobblemonExtendedBattleUI.LOGGER.warn("ServerPanelConfig: Failed to load, using defaults: ${e.message}")
+            data = Data()
+        }
+    }
+
+    fun save() {
+        try {
+            configFile.parentFile?.mkdirs()
+            configFile.writeText(gson.toJson(data))
+        } catch (e: Exception) {
+            CobblemonExtendedBattleUI.LOGGER.warn("ServerPanelConfig: Failed to save: ${e.message}")
+        }
+    }
+
+    /**
+     * Build payload for a joining client: only entries whose sync_* flag is true.
+     */
+    fun buildSyncPayload(): FeatureSyncS2CPayload {
+        val d = data
+        val entries = mutableListOf<Pair<String, Boolean>>()
+        fun addIfSynced(sync: Boolean, key: String, value: Boolean) {
+            if (sync) entries.add(key to value)
+        }
+        addIfSynced(d.sync_enableTeamIndicators, "enableTeamIndicators", d.enableTeamIndicators)
+        addIfSynced(d.sync_teamIndicatorRepositioningEnabled, "teamIndicatorRepositioningEnabled", d.teamIndicatorRepositioningEnabled)
+        addIfSynced(d.sync_enableBattleInfoPanel, "enableBattleInfoPanel", d.enableBattleInfoPanel)
+        addIfSynced(d.sync_enableBattleLog, "enableBattleLog", d.enableBattleLog)
+        addIfSynced(d.sync_enableBattleLogDamagePercentages, "enableBattleLogDamagePercentages", d.enableBattleLogDamagePercentages)
+        addIfSynced(d.sync_enableMoveTooltips, "enableMoveTooltips", d.enableMoveTooltips)
+        addIfSynced(d.sync_showTeraType, "showTeraType", d.showTeraType)
+        addIfSynced(d.sync_showStatRanges, "showStatRanges", d.showStatRanges)
+        addIfSynced(d.sync_showOpponentSpeedRange, "showOpponentSpeedRange", d.showOpponentSpeedRange)
+        addIfSynced(d.sync_showBaseCritRate, "showBaseCritRate", d.showBaseCritRate)
+        return FeatureSyncS2CPayload(FeatureSyncS2CPayload.SCHEMA_VERSION, entries)
+    }
+}

--- a/src/main/kotlin/com/cobblemonextendedbattleui/TeamIndicatorUI.kt
+++ b/src/main/kotlin/com/cobblemonextendedbattleui/TeamIndicatorUI.kt
@@ -819,7 +819,7 @@ object TeamIndicatorUI {
         val isAltDown = GLFW.glfwGetKey(handle, GLFW.GLFW_KEY_LEFT_ALT) == GLFW.GLFW_PRESS ||
             GLFW.glfwGetKey(handle, GLFW.GLFW_KEY_RIGHT_ALT) == GLFW.GLFW_PRESS
 
-        val repositioningEnabled = PanelConfig.teamIndicatorRepositioningEnabled
+        val repositioningEnabled = PanelConfig.teamIndicatorRepositioningEnabledEffective
 
         // Handle drag in progress (only if repositioning is enabled)
         if (isDragging && repositioningEnabled) {
@@ -1416,7 +1416,7 @@ object TeamIndicatorUI {
         TeamPanelRenderer.renderControlHints(
             context, bounds, isLeftSide,
             !isInDefaultState(isLeftSide),
-            PanelConfig.teamIndicatorRepositioningEnabled,
+            PanelConfig.teamIndicatorRepositioningEnabledEffective,
             ::applyOpacity
         )
     }

--- a/src/main/kotlin/com/cobblemonextendedbattleui/network/FeatureSyncS2CPayload.kt
+++ b/src/main/kotlin/com/cobblemonextendedbattleui/network/FeatureSyncS2CPayload.kt
@@ -1,0 +1,47 @@
+package com.cobblemonextendedbattleui.network
+
+import com.cobblemonextendedbattleui.CobblemonExtendedBattleUI
+import net.minecraft.network.RegistryByteBuf
+import net.minecraft.network.codec.PacketCodec
+import net.minecraft.network.packet.CustomPayload
+import net.minecraft.util.Identifier
+
+/**
+ * Server → client: feature toggle values the server owner chose to sync.
+ * Only keys present in [entries] override the client's local config (server-forced).
+ */
+data class FeatureSyncS2CPayload(
+    val schemaVersion: Int,
+    val entries: List<Pair<String, Boolean>>
+) : CustomPayload {
+
+    override fun getId(): CustomPayload.Id<FeatureSyncS2CPayload> = ID
+
+    companion object {
+        val ID = CustomPayload.Id<FeatureSyncS2CPayload>(
+            Identifier.of(CobblemonExtendedBattleUI.MOD_ID, "feature_sync")
+        )
+
+        const val SCHEMA_VERSION: Int = 1
+
+        val CODEC: PacketCodec<RegistryByteBuf, FeatureSyncS2CPayload> = CustomPayload.codecOf(
+            { payload, buf ->
+                buf.writeVarInt(payload.schemaVersion)
+                buf.writeVarInt(payload.entries.size)
+                for ((key, value) in payload.entries) {
+                    buf.writeString(key)
+                    buf.writeBoolean(value)
+                }
+            },
+            { buf ->
+                val version = buf.readVarInt()
+                val n = buf.readVarInt()
+                val list = ArrayList<Pair<String, Boolean>>(n)
+                repeat(n) {
+                    list.add(buf.readString() to buf.readBoolean())
+                }
+                FeatureSyncS2CPayload(version, list)
+            }
+        )
+    }
+}

--- a/src/main/kotlin/com/cobblemonextendedbattleui/network/FeatureSyncS2CPayload.kt
+++ b/src/main/kotlin/com/cobblemonextendedbattleui/network/FeatureSyncS2CPayload.kt
@@ -23,6 +23,7 @@ data class FeatureSyncS2CPayload(
         )
 
         const val SCHEMA_VERSION: Int = 1
+        private const val MAX_FEATURE_SYNC_ENTRIES: Int = 64
 
         val CODEC: PacketCodec<RegistryByteBuf, FeatureSyncS2CPayload> = CustomPayload.codecOf(
             { payload, buf ->
@@ -35,7 +36,7 @@ data class FeatureSyncS2CPayload(
             },
             { buf ->
                 val version = buf.readVarInt()
-                val n = buf.readVarInt()
+                val n = buf.readVarInt().coerceIn(0, MAX_FEATURE_SYNC_ENTRIES)
                 val list = ArrayList<Pair<String, Boolean>>(n)
                 repeat(n) {
                     list.add(buf.readString() to buf.readBoolean())

--- a/src/main/resources/assets/cobblemonextendedbattleui/lang/en_us.json
+++ b/src/main/resources/assets/cobblemonextendedbattleui/lang/en_us.json
@@ -18,7 +18,10 @@
   "cobblemonextendedbattleui.config.enableBattleInfoPanel.tooltip": "Show panel with weather, terrain, field conditions, and stat stages",
 
   "cobblemonextendedbattleui.config.enableBattleLog": "Battle Log",
-  "cobblemonextendedbattleui.config.enableBattleLog.tooltip": "Show custom battle log widget with damage percentages",
+  "cobblemonextendedbattleui.config.enableBattleLog.tooltip": "Show the custom on-screen battle log instead of Cobblemon's chat-based battle messages. Optional damage and healing percentage lines are configured below.",
+
+  "cobblemonextendedbattleui.config.enableBattleLogDamagePercentages": "Damage Percentages",
+  "cobblemonextendedbattleui.config.enableBattleLogDamagePercentages.tooltip": "When Battle Log is enabled, add extra lines showing damage and healing as a percentage of max HP. Requires Battle Log (above) to be enabled; this option is disabled while Battle Log is off.",
 
   "cobblemonextendedbattleui.config.enableMoveTooltips": "Move Tooltips",
   "cobblemonextendedbattleui.config.enableMoveTooltips.tooltip": "Show tooltips with type effectiveness when hovering over moves. Disable if using Cobblemon Move Inspector.",
@@ -27,7 +30,10 @@
   "cobblemonextendedbattleui.config.showTeraType.tooltip": "Display Tera Type in Pokemon tooltips when known",
 
   "cobblemonextendedbattleui.config.showStatRanges": "Show Stat Values",
-  "cobblemonextendedbattleui.config.showStatRanges.tooltip": "Display Attack, Defense, Sp. Atk, and Sp. Def in Pokemon tooltips (Speed is always shown)",
+  "cobblemonextendedbattleui.config.showStatRanges.tooltip": "Display stat values for your Pokemon in tooltips (Attack, Defense, Sp. Atk, Sp. Def, Speed). Independent of opponent speed range below.",
+
+  "cobblemonextendedbattleui.config.showOpponentSpeedRange": "Opponent Speed Range",
+  "cobblemonextendedbattleui.config.showOpponentSpeedRange.tooltip": "Show estimated min–max Speed next to the Speed row for opponent Pokemon. The Speed label and stage are always shown; only the range numbers are hidden when this is off. Independent of Show Stat Values.",
 
   "cobblemonextendedbattleui.config.showBaseCritRate": "Show Base Crit Rate",
   "cobblemonextendedbattleui.config.showBaseCritRate.tooltip": "Always show crit rate in move tooltips. When disabled, only shows crit rate for high-crit moves or when boosted by items/abilities.",

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -11,7 +11,7 @@
   },
   "license": "MIT",
   "icon": "assets/cobblemonextendedbattleui/icon.png",
-  "environment": "client",
+  "environment": "*",
   "entrypoints": {
     "client": [
       {


### PR DESCRIPTION
## Description

As I explained in issue https://github.com/sveniik/CobblemonExtendedBattleUI/issues/31 server owners are forced to be at the expenses of player's configuration. Certain configurations may be controversial among certain hardcore competitive fans. Making a server config file ensures all the players are in equal conditions in tournaments.

New features added:

- Sync server side config, forcing players to use the server config instead, only when server owners decide it.
- Different config option for enabling/disalbing damage percentages.
- Config option to disable seeing the Speed stat from the oponnent's pokémon.

## Type of Change
- [x] New feature
- [x] Enhancement to existing feature

## Testing
<!-- How did you test this? Include steps to reproduce/verify -->
Local Arclight Server and Testing Dedicated Server.
Changed all the features and ensuring all the sync true false is working.

## Checklist
- [x] I've tested this in-game during a battle
- [x] This doesn't break existing functionality
- [x] My code follows the existing style of the project
- [x] I've tested with different panel sizes/positions, as well as GUI scales in native settings
