### PR TITLE
fix: ensure widget positioning respects screen boundaries

### DIFF
--- a/src/main/kotlin/com/cobblemonextendedbattleui/BattleLogWidget.kt
+++ b/src/main/kotlin/com/cobblemonextendedbattleui/BattleLogWidget.kt
@@ -179,9 +179,15 @@ object BattleLogWidget {
 
         // Calculate Y from bottom edge (collapse downwards behavior)
         val bottomY = (PanelConfig.logY ?: (defaultBottomY - expandedHeight)) + expandedHeight
-        val y = (bottomY - height).coerceIn(0, screenHeight - height)
-        val x = (PanelConfig.logX ?: defaultX).coerceIn(0, screenWidth - width)
+        val safeHeight = height.coerceAtMost(screenHeight)
+        val safeWidth = width.coerceAtMost(screenWidth)
 
+        val maxY = (screenHeight - safeHeight).coerceAtLeast(0)
+        val maxX = (screenWidth - safeWidth).coerceAtLeast(0)
+
+        val y = (bottomY - safeHeight).coerceIn(0, maxY)
+        val x = (PanelConfig.logX ?: defaultX).coerceIn(0, maxX)
+        
         widgetX = x
         widgetY = y
         widgetW = width

--- a/src/main/kotlin/com/cobblemonextendedbattleui/PokemonInfoPopup.kt
+++ b/src/main/kotlin/com/cobblemonextendedbattleui/PokemonInfoPopup.kt
@@ -100,13 +100,13 @@ object PokemonInfoPopup {
             }
             // Vertically centered on the hovered pokeball, clamped to screen
             py = bounds.y + (bounds.height / 2) - (totalHeight / 2)
-            px = px.coerceIn(4, screenWidth - popupWidth - 4)
-            py = py.coerceIn(4, screenHeight - totalHeight - 4)
+            px = px.coerceIn(4, maxOf(4, screenWidth - popupWidth - 4))
+            py = py.coerceIn(4, maxOf(4, screenHeight - totalHeight - 4))
         } else {
             // Horizontal team layout: popup appears below the pokeball
             px = bounds.x + (bounds.width / 2) - (popupWidth / 2)
             py = bounds.y + bounds.height + 4
-            px = px.coerceIn(4, screenWidth - popupWidth - 4)
+            px = px.coerceIn(4, maxOf(4, screenWidth - popupWidth - 4))
             if (py + totalHeight > screenHeight - 4) {
                 py = bounds.y - totalHeight - 4
             }


### PR DESCRIPTION
# Description
Fix the crash in Issue #34.

# Type of Change
[#34 ] Bug fix

# Testing
Expand the battle log a lot and click en the white bar
When you minimize the game from the white bar on the top of the program and the battle log is in a massive size is going to crash the game

# Checklist
[ ✅ ] I've tested this in-game during a battle
[ ✅ ] This doesn't break existing functionality
[ ✅ ] My code follows the existing style of the project
[ ✅ ] I've tested with different panel sizes/positions, as well as GUI scales in native settings